### PR TITLE
Update urllib3 version to patch vulnerabilities

### DIFF
--- a/dlaas/tuilib/common.py
+++ b/dlaas/tuilib/common.py
@@ -43,7 +43,7 @@ def sanitize_dictionary(dictionary: Dict[str, str]) -> None:
         "port": [r"[0-9]+"],  # any number
         "database": [r"[a-zA-Z0-9_]+"],  # any single word
         "collection": [r"[a-zA-Z0-9_]+"],  # any single word
-        "s3_endpoint_url": [r"(https?:\/\/)?([a-zA-Z0-9_-]+\.)+[a-zA-Z0-9_-]+\/?"],  # "https://XXX.(XXX.)*n.XXX/",
+        "s3_endpoint_url": [r"(https?:\/\/)?([a-zA-Z0-9_-]+\.)+[a-zA-Z0-9_-]+(:[0-9]+)?\/?"],  # "https://XXX.(XXX.)*n.XXX:XXXX/",
         "s3_bucket": [r"[a-zA-Z0-9_]+"],  # any single word
         "pfs_prefix_path": [
             r"\/([a-zA-Z0-9_-]+\/?)+"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ sh
 wheel
 pymongo==4.5.0
 python-dateutil==2.6.0
-urllib3>=1.26.19
+urllib3==1.26.19
 pyparsing
 sqlparse @ git+https://github.com/lbabetto/sqlparse
 boto3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ sh
 wheel
 pymongo==4.5.0
 python-dateutil==2.6.0
-urllib3==1.26
+urllib3>=1.26.19
 pyparsing
 sqlparse @ git+https://github.com/lbabetto/sqlparse
 boto3

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "wheel",
         "pymongo==4.5.0",
         "python-dateutil==2.6.0",
-        "urllib3==1.26",
+        "urllib3>=1.26.19",
         "pyparsing",
         "sqlparse @ git+https://github.com/lbabetto/sqlparse",
         "boto3",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "wheel",
         "pymongo==4.5.0",
         "python-dateutil==2.6.0",
-        "urllib3>=1.26.19",
+        "urllib3==1.26.19",
         "pyparsing",
         "sqlparse @ git+https://github.com/lbabetto/sqlparse",
         "boto3",


### PR DESCRIPTION
Required `urllib3` version has been updated from `1.26` to `1.26.19`.

Tests were carried out launching commands using the TUI and API on the same urllib3 version, everything looks okay.

Closes #2 