### PR TITLE
Update minimum PyMongo version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 sh
 wheel
-pymongo==4.5.0
+pymongo==4.6.3
 python-dateutil==2.6.0
 urllib3==1.26.19
 pyparsing

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     install_requires=[
         "sh",
         "wheel",
-        "pymongo==4.5.0",
+        "pymongo==4.6.3",
         "python-dateutil==2.6.0",
         "urllib3==1.26.19",
         "pyparsing",


### PR DESCRIPTION
Required `pymongo` version has been updated from `4.5.0` to `4.6.3`

Tests were carried out launching commands using the TUI and API on the same pymongo version, everything looks okay.

Closes #3 